### PR TITLE
Ot99 48 endpoint delete news

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/NewsController.java
+++ b/src/main/java/com/alkemy/ong/controller/NewsController.java
@@ -18,5 +18,11 @@ public class NewsController {
     public ResponseEntity<NewsDto> getById(@PathVariable Long id) throws NotFoundException {
         return new ResponseEntity<>(newsService.getById(id), HttpStatus.OK);
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteNew(@PathVariable Long id) throws NotFoundException {
+        newsService.deleteNew(id);
+        return new ResponseEntity<>("The new was deleted successfuly", HttpStatus.OK);
+    }
+
 }
-    

--- a/src/main/java/com/alkemy/ong/service/NewsService.java
+++ b/src/main/java/com/alkemy/ong/service/NewsService.java
@@ -2,10 +2,10 @@ package com.alkemy.ong.service;
 
 import com.alkemy.ong.dto.NewsDto;
 import com.alkemy.ong.exception.NotFoundException;
-import com.alkemy.ong.model.News;
-
-import java.util.List;
 
 public interface NewsService {
-    public NewsDto getById(Long id) throws NotFoundException;
+
+    NewsDto getById(Long id) throws NotFoundException;
+
+    void deleteNew(Long id) throws NotFoundException;
 }

--- a/src/main/java/com/alkemy/ong/service/impl/NewsServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/NewsServiceImpl.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.service.impl;
 
+import java.time.LocalDate;
+
 import com.alkemy.ong.dto.NewsDto;
 import com.alkemy.ong.exception.NotFoundException;
 import com.alkemy.ong.model.News;
@@ -10,11 +12,22 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class NewsServiceImpl implements NewsService {
+    
     @Autowired
-    private NewsRepository repo;
+    private NewsRepository newsRepository;
+
     @Override
     public NewsDto getById(Long id) throws NotFoundException {
-        News news = repo.findById(id).orElseThrow(() -> new NotFoundException("The news is not registered."));
+        News news = newsRepository.findById(id).orElseThrow(() -> new NotFoundException("The news is not registered."));
         return NewsDto.mapToDto(news);
+    }
+
+    @Override
+    public void deleteNew(Long id) throws NotFoundException {
+        News news = newsRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("The new of id:" + id + " was not found"));
+        news.setDeletedDate(LocalDate.now());
+        news.setDeleted(true);
+        newsRepository.save(news);
     }
 }


### PR DESCRIPTION
**Summary**

1. Added NewsRepository
2. Added NewsService interface
3. Added NewsServiceImpl implementation
4. Created endpoint DELETE /news/{id}
5. Created logic in service that do the soft delete and set the delete date
**Evidence**
sql: select*from news;
![evidence](https://user-images.githubusercontent.com/83930746/141162484-9ef1fd51-bc61-4a6d-8760-7cf92024d093.png)
![evidence1](https://user-images.githubusercontent.com/83930746/141162511-0b5c4279-bc07-4fbc-b90a-e6ca2a1147e0.png)
sql: select*from news; after calling the endpoint
![evidence3](https://user-images.githubusercontent.com/83930746/141162558-ffc96ccf-7470-47b4-96ff-c991722e06b3.png)
calling the enpoint again, we can see that, cause the soft delete, doesnt found a new
![evidence2](https://user-images.githubusercontent.com/83930746/141162715-1001e663-2294-4ce8-b9a5-dea62b0f05b7.png)
