### PR TITLE
Ot99-67- delete testimonial endpoint

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/controller/TestimonialController.java
@@ -13,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 
@@ -33,6 +34,12 @@ public class TestimonialController {
     public ResponseEntity<Testimonial> update(@Valid @RequestBody TestimonialRequest testimonialRequest, @PathVariable Long id) throws NotFoundException, DataAlreadyExistException {
         return new ResponseEntity<>(testimonialService.updateTestimonial(id, testimonialRequest), HttpStatus.OK);
 
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> delete(@PathVariable Long id) throws NotFoundException {
+        testimonialService.delete(id);
+        return new ResponseEntity<>("Testimonial has been deleted", HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/alkemy/ong/security/SecurityConfiguration.java
+++ b/src/main/java/com/alkemy/ong/security/SecurityConfiguration.java
@@ -33,7 +33,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     String[] adminAuthorizedEndpoint = {
     		"/users",
-        "testimonials/",
+        "testimonials/**",
             "/news/{id}",
             "/activities/{id}",
             "/categories/{id}",                               
@@ -42,7 +42,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     String[] adminPostAuthorizedEndpoint = {"/organization/public","/news"};
   
-    String[] adminPutAuthorizedEndpoint = {"/news/{id}", "/testimonials/{id}"};
+    String[] adminPutAuthorizedEndpoint = {"/news/{id}"};
     
     @Override
     protected void configure(HttpSecurity http) throws Exception {

--- a/src/main/java/com/alkemy/ong/service/TestimonialService.java
+++ b/src/main/java/com/alkemy/ong/service/TestimonialService.java
@@ -9,4 +9,6 @@ public interface TestimonialService {
 
     public Testimonial save(TestimonialRequest testimonialRequest) throws DataAlreadyExistException;
     public Testimonial updateTestimonial(Long id, TestimonialRequest testimonialRequest) throws NotFoundException, DataAlreadyExistException;
+
+    public void delete(Long id) throws NotFoundException;
 }

--- a/src/main/java/com/alkemy/ong/service/impl/TestimonialServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/TestimonialServiceImpl.java
@@ -14,43 +14,49 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class TestimonialServiceImpl implements TestimonialService {
-    
+
     @Autowired
     TestimonialMapper testimonialMapper;
     @Autowired
     TestimonialRepository testimonialRepository;
-    
+
     @Override
     public Testimonial save(TestimonialRequest testimonialRequest) throws DataAlreadyExistException {
-        
+
         if ((testimonialRepository.findByName(testimonialRequest.getName()).isPresent())) {
             throw new DataAlreadyExistException("This testimonial's name has already been used");
         }
-        
+
         testimonialRequest.setLastUpdated(Date.from(Instant.now()));
         Testimonial testimonial = testimonialMapper.dtoToEntity(testimonialRequest);
         testimonial.setCreationDate(Date.from(Instant.now()));
         return testimonialRepository.save(testimonial);
-        
+
     }
-    
+
     @Override
     public Testimonial updateTestimonial(Long id, TestimonialRequest testimonialRequest) throws NotFoundException, DataAlreadyExistException {
-        
+
         if (!testimonialRepository.findById(id).isPresent()) {
-            
+
             throw new NotFoundException("Testimonial could not be found");
-            
+
         }
         if ((testimonialRepository.findByName(testimonialRequest.getName()).isPresent())) {
             throw new DataAlreadyExistException("This testimonial's name has already been used");
         }
-        
+
         Testimonial testimonial = testimonialRepository.findById(id).get();
         testimonialMapper.updateEntity(testimonialRequest, testimonial);
         testimonial.setLastUpdated(Date.from(Instant.now()));
         return testimonialRepository.save(testimonial);
-        
+
     }
-    
+
+    @Override
+    public void delete(Long id) throws NotFoundException {
+        testimonialRepository.findById(id).orElseThrow(() -> new NotFoundException("Testimonial could not be found"));
+        testimonialRepository.deleteById(id);
+    }
+
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/80407833/142205242-c949e950-2905-4412-ba4f-d8485ebe3d66.png)
![image](https://user-images.githubusercontent.com/80407833/142205257-796b3170-7e81-4ebd-a3e9-3ba54dcb5b27.png)
![image](https://user-images.githubusercontent.com/80407833/142205270-1e209771-eb1f-43e5-9182-7da0391ecbc0.png)
![image](https://user-images.githubusercontent.com/80407833/142205291-79668581-88a3-4ef6-b60f-cb48f00d530c.png)
![image](https://user-images.githubusercontent.com/80407833/142205314-5164f6cd-7c72-4160-84e3-9deeaf2c0efa.png)
- Added delete function to testimonials endpoint
- When testimonial not found throws error
- Configured testimonial in configuration to accept all requests from admins