### PR TITLE
Fix Base64DecodedMultipartFile name

### DIFF
--- a/src/main/java/com/alkemy/ong/model/BASE64DecodedMultipartFile.java
+++ b/src/main/java/com/alkemy/ong/model/BASE64DecodedMultipartFile.java
@@ -1,3 +1,4 @@
+
 package com.alkemy.ong.model;
 
 import java.io.ByteArrayInputStream;
@@ -6,6 +7,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.springframework.web.multipart.MultipartFile;
+
 
 public class Base64DecodedMultipartFile implements MultipartFile {
 
@@ -62,4 +64,5 @@ public class Base64DecodedMultipartFile implements MultipartFile {
     public void transferTo(File dest) throws IOException, IllegalStateException {
         new FileOutputStream(dest).write(imgContent);
     }
+
 }

--- a/src/main/java/com/alkemy/ong/model/Base64MultipartFile.java
+++ b/src/main/java/com/alkemy/ong/model/Base64MultipartFile.java
@@ -9,8 +9,9 @@ import java.io.InputStream;
 import org.springframework.web.multipart.MultipartFile;
 
 
-public class Base64DecodedMultipartFile implements MultipartFile {
+public class Base64MultipartFile implements MultipartFile {
 
+    
     private final byte[] imgContent;
     private String name;
 
@@ -19,7 +20,7 @@ public class Base64DecodedMultipartFile implements MultipartFile {
     }
      
 
-    public Base64DecodedMultipartFile(byte[] imgContent) {
+    public Base64MultipartFile(byte[] imgContent) {
         this.imgContent = imgContent;
     }
 

--- a/src/main/java/com/alkemy/ong/service/ImageService.java
+++ b/src/main/java/com/alkemy/ong/service/ImageService.java
@@ -1,11 +1,11 @@
 package com.alkemy.ong.service;
 
-import com.alkemy.ong.model.Base64DecodedMultipartFile;
+import com.alkemy.ong.model.Base64MultipartFile;
 
 
 public interface ImageService {
 
-    public String uploadFile(Base64DecodedMultipartFile file);
-    public Base64DecodedMultipartFile convert(String image);
+    public String uploadFile(Base64MultipartFile file);
+    public Base64MultipartFile convert(String image);
 
 }

--- a/src/main/java/com/alkemy/ong/service/impl/ImageServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/ImageServiceImpl.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.util.Date;
 
 import com.alkemy.ong.config.AmazonS3Config;
-import com.alkemy.ong.model.Base64DecodedMultipartFile;
+import com.alkemy.ong.model.Base64MultipartFile;
 import com.alkemy.ong.service.ImageService;
 
 import com.amazonaws.services.s3.model.CannedAccessControlList;
@@ -23,7 +23,7 @@ public class ImageServiceImpl implements ImageService {
     AmazonS3Config amazonS3Config;
 
     @Override
-    public String uploadFile(Base64DecodedMultipartFile multipartFile) {
+    public String uploadFile(Base64MultipartFile multipartFile) {
         String fileUrl = "";
         try {
             File file = convertMultiPartToFile(multipartFile);
@@ -37,7 +37,7 @@ public class ImageServiceImpl implements ImageService {
         return fileUrl;
     }
 
-    private File convertMultiPartToFile(Base64DecodedMultipartFile file) throws IOException {
+    private File convertMultiPartToFile(Base64MultipartFile file) throws IOException {
         File convFile = new File(file.getOriginalFilename());
         FileOutputStream fos = new FileOutputStream(convFile);
         fos.write(file.getBytes());
@@ -45,7 +45,7 @@ public class ImageServiceImpl implements ImageService {
         return convFile;
     }
 
-    private String generateFileName(Base64DecodedMultipartFile multiPart) {
+    private String generateFileName(Base64MultipartFile multiPart) {
         return new Date().getTime() + "-" + multiPart.getOriginalFilename().replace(" ", "_");
     }
 
@@ -55,9 +55,9 @@ public class ImageServiceImpl implements ImageService {
     }
 
     @Override
-    public Base64DecodedMultipartFile convert(String image) {
+    public Base64MultipartFile convert(String image) {
         byte[] result = Base64.getDecoder().decode(image);
-        Base64DecodedMultipartFile file = new Base64DecodedMultipartFile(result);
+        Base64MultipartFile file = new Base64MultipartFile(result);
         return file;
     }
 

--- a/src/main/java/com/alkemy/ong/service/impl/SlideServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/SlideServiceImpl.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 import com.alkemy.ong.dto.SlideDto;
 
 import com.alkemy.ong.dto.SlideDtoPost;
-import com.alkemy.ong.model.Base64DecodedMultipartFile;
+import com.alkemy.ong.model.Base64MultipartFile;
 import com.alkemy.ong.model.Organization;
 
 import com.alkemy.ong.model.Slide;
@@ -43,7 +43,7 @@ public class SlideServiceImpl implements SlideService {
     @Override
     public Slide create(SlideDtoPost slideDtoPost) {
         Slide slide = slideMapper.dtoToEntity(slideDtoPost);
-        Base64DecodedMultipartFile file = imageService.convert(slide.getImageUrl());
+        Base64MultipartFile file = imageService.convert(slide.getImageUrl());
         String name = UUID.randomUUID().toString();
         String extension = ".jpg";
         file.setName(name + extension);


### PR DESCRIPTION
Changed filename from BASE64 to base64, it seems that there was a problem at the time of refactoring, as inside class name  was in lowercase while class name remained in UPPERCASE